### PR TITLE
device rework

### DIFF
--- a/aosp_sgp511.mk
+++ b/aosp_sgp511.mk
@@ -14,10 +14,7 @@
 
 TARGET_KERNEL_CONFIG := aosp_shinano_castor_defconfig
 
-$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
-$(call inherit-product, device/sony/castor_windy/aosp_sgp5xx_common.mk)
-
-PRODUCT_COPY_FILES += \
+PRODUCT_COPY_FILES := \
     frameworks/native/data/etc/tablet_core_hardware.xml:system/etc/permissions/tablet_core_hardware.xml
 
 PRODUCT_PROPERTY_OVERRIDES += \
@@ -40,6 +37,10 @@ PRODUCT_PACKAGES += \
 # NFC config
 PRODUCT_PACKAGES += \
     nfc_nci.castor_windy
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, device/sony/castor_windy/aosp_sgp5xx_common.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 
 PRODUCT_NAME := aosp_sgp511
 PRODUCT_DEVICE := castor_windy

--- a/aosp_sgp5xx_common.mk
+++ b/aosp_sgp5xx_common.mk
@@ -15,10 +15,6 @@
 DEVICE_PACKAGE_OVERLAYS += \
     device/sony/castor_windy/overlay
 
-$(call inherit-product, device/sony/shinano/platform.mk)
-$(call inherit-product, vendor/sony/castor/castor-vendor.mk)
-$(call inherit-product, frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)
-
 PRODUCT_COPY_FILES += \
     device/sony/castor_windy/rootdir/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
     device/sony/castor_windy/rootdir/system/etc/BCM4339.hcd:system/etc/firmware/BCM43xx.hcd \
@@ -66,6 +62,10 @@ PRODUCT_AAPT_PREF_CONFIG := hdpi
 
 PRODUCT_CHARACTERISTICS := tablet
 
-PRODUCT_PROPERTY_OVERRIDES += \
+PRODUCT_PROPERTY_OVERRIDES := \
     ro.sf.lcd_density=240 \
     ro.usb.pid_suffix=1B1
+
+$(call inherit-product, device/sony/shinano/platform.mk)
+$(call inherit-product, vendor/sony/castor/castor-vendor.mk)
+$(call inherit-product, frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)


### PR DESCRIPTION
We split device from aosp_device so that it can be included
easy in custom projects.

New projects should create a new target named <project>_device
which contains project specific configuration and options.

Signed-off-by: Alin Jerpelea alin.jerpelea@sonymobile.com
